### PR TITLE
Fix deptrecated use of set-output in GitHub Action workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: arnested/go-version-action@v1
       id: version
-    - run: echo ::set-output name=go-runtime::$(echo -n go${{ steps.version.outputs.go-mod-version }} | tr -d '.')
+    - run: echo name=go-runtime::$(echo -n go${{ steps.version.outputs.go-mod-version }} | tr -d '.') >> $GITHUB_OUTPUT
       id: runtime
     - uses: google-github-actions/auth@v2
       with:


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
